### PR TITLE
feat: create schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 bun.lockb
+bun.lock
 .DS_Store
 sst-env.d.ts

--- a/README.md
+++ b/README.md
@@ -63,24 +63,6 @@ export const auth = betterAuth({
 });
 ```
 
-### Records Enabled Setup
-
-When enabling records, all fields ending with 'Id' will be treated as a SurrealDb RecordId. You may need to inspect some plugins to ensure that they do not use this pattern. The following updates the reserved schemas.
-
-```typescript
-export const auth = betterAuth({
-	database: surrealAdapter(surrealdb, {
-		enableRecords: true,
-	}),
-	account: {
-		fields: {
-			accountId: "subject", // renames 'accountId' to 'subject'
-			providerId: "name",		// renames 'providerId' to 'name'
-		},
-	},
-});
-```
-
 ## 📋 Schema Generation
 
 You can automatically run to generate a schema based on your configuration to a Surql file.

--- a/README.md
+++ b/README.md
@@ -43,123 +43,68 @@ yarn add surrealdb-better-auth
 
 ```typescript
 import { surrealAdapter } from "surrealdb-better-auth";
+import { Surreal } from 'surrealdb'
+
+const surrealdb = new Surreal()
+surrealdb.connect(
+	process.env.SURREALDB_ADDRESS ?? "http://localhost:8000", {
+	namespace: process.env.SURREALDB_NAMESPACE ?? "namespace",
+	database: process.env.SURREALDB_DATABASE ?? "database",
+	auth: {
+		username: process.env.SURREALDB_AUTH_USERNAME ?? "root",
+		password: process.env.SURREALDB_AUTH_PASSWORD ??"root",
+	},
+	reconnect: true,
+})
 
 export const auth = betterAuth({
 	// ... other Better Auth options
-	database: surrealAdapter({
-		address: "http://localhost:8000", // Your SurrealDB server address
-		username: "root", // Your SurrealDB username
-		password: "root", // Your SurrealDB password
-		ns: "namespace", // Your namespace
-		db: "database", // Your database name
-	}),
+	database: surrealAdapter(surrealdb),
 });
 ```
 
-### Environment Variables Setup
+### Records Enabled Setup
+
+When enabling records, all fields ending with 'Id' will be treated as a SurrealDb RecordId. You may need to inspect some plugins to ensure that they do not use this pattern. The following updates the reserved schemas.
 
 ```typescript
-import { surrealAdapter } from "surrealdb-better-auth";
-
 export const auth = betterAuth({
-	// ... other Better Auth options
-	database: surrealAdapter({
-		address: process.env.SURREALDB_ADDRESS,
-		username: process.env.SURREALDB_USERNAME,
-		password: process.env.SURREALDB_PASSWORD,
-		ns: process.env.SURREALDB_NAMESPACE,
-		db: process.env.SURREALDB_DATABASE,
+	database: surrealAdapter(surrealdb, {
+		enableRecords: true,
 	}),
+	account: {
+		fields: {
+			accountId: "subject", // renames 'accountId' to 'subject'
+			providerId: "name",		// renames 'providerId' to 'name'
+		},
+	},
 });
 ```
 
-## 📋 Schema Definitions
+## 📋 Schema Generation
 
-### Default Schemas
+You can automatically run to generate a schema based on your configuration to a Surql file.
 
-#### Account Table
-
-```sql
-DEFINE TABLE account TYPE ANY SCHEMALESS COMMENT 'better-auth: accounts' PERMISSIONS NONE;
-DEFINE FIELD accountId ON account TYPE record<user> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD createdAt ON account TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD id ON account TYPE string PERMISSIONS FULL;
-DEFINE FIELD password ON account TYPE string PERMISSIONS FULL;
-DEFINE FIELD providerId ON account TYPE string PERMISSIONS FULL;
-DEFINE FIELD updatedAt ON account TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD userId ON account TYPE record<user> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
+```sh
+npx @better-auth/cli generate
 ```
 
-#### Session Table
+You can also perform this in javascript to print to console:
 
-```sql
-DEFINE TABLE session TYPE ANY SCHEMALESS COMMENT 'better-auth: sessions' PERMISSIONS NONE;
-DEFINE FIELD activeOrganizationId ON session TYPE option<record<organization>> REFERENCE ON DELETE UNSET COMMENT 'The id of the active organization' PERMISSIONS FULL;
-DEFINE FIELD createdAt ON session TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD expiresAt ON session PERMISSIONS FULL;
-DEFINE FIELD id ON session TYPE string PERMISSIONS FULL;
-DEFINE FIELD ipAddress ON session TYPE string PERMISSIONS FULL;
-DEFINE FIELD token ON session TYPE string PERMISSIONS FULL;
-DEFINE FIELD updatedAt ON session TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD userId ON session TYPE record<user> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-```
+```typescript
+const adapterFunc = surrealAdapter(surreal);
 
-#### User Table
+_auth = betterAuth({
+	// ... other Better Auth options
+	database: surrealFunc,
+	plugins: [
+		// ... works with plugins too
+	]
+});
 
-```sql
-DEFINE TABLE user TYPE ANY SCHEMALESS COMMENT 'better-auth: users' PERMISSIONS NONE;
-DEFINE FIELD chats ON user TYPE references<chat> PERMISSIONS FULL;
-DEFINE FIELD defaultOrganizationId ON user TYPE option<record<organization>> PERMISSIONS FULL;
-DEFINE FIELD organizations ON user TYPE references<member> PERMISSIONS FULL;
-```
-
-### Orgs Plugin Schemas
-
-#### Organization Table
-
-```sql
-DEFINE TABLE organization TYPE NORMAL SCHEMALESS COMMENT 'better-auth orgs: organizations' PERMISSIONS NONE;
-DEFINE FIELD createdAt ON organization TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD logo ON organization TYPE option<string> COMMENT 'The logo of the organization' PERMISSIONS FULL;
-DEFINE FIELD metadata ON organization FLEXIBLE TYPE option<object> COMMENT 'Additional metadata for the organization' PERMISSIONS FULL;
-DEFINE FIELD name ON organization TYPE string PERMISSIONS FULL;
-DEFINE FIELD slug ON organization TYPE string PERMISSIONS FULL;
-DEFINE FIELD updatedAt ON organization TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-```
-
-#### Member Table
-
-```sql
-DEFINE TABLE member TYPE NORMAL SCHEMALESS COMMENT 'better-auth orgs: members' PERMISSIONS NONE;
-DEFINE FIELD createdAt ON member TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD organizationId ON member TYPE record<organization> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD role ON member TYPE string PERMISSIONS FULL;
-DEFINE FIELD teamId ON member TYPE option<record<team>> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD userId ON member TYPE record<user> REFERENCE ON DELETE IGNORE PERMISSIONS FULL;
-```
-
-#### Team Table
-
-```sql
-DEFINE TABLE team TYPE NORMAL SCHEMALESS COMMENT 'better-auth orgs: teams' PERMISSIONS NONE;
-DEFINE FIELD createdAt ON team TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD name ON team TYPE string PERMISSIONS FULL;
-DEFINE FIELD organizationId ON team TYPE record<organization> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD updatedAt ON team TYPE option<datetime> DEFAULT time::now() PERMISSIONS FULL;
-```
-
-#### Invitation Table
-
-```sql
-DEFINE TABLE invitation TYPE NORMAL SCHEMALESS COMMENT 'better-auth orgs: invitations' PERMISSIONS NONE;
-DEFINE FIELD createdAt ON invitation TYPE datetime DEFAULT time::now() PERMISSIONS FULL;
-DEFINE FIELD email ON invitation TYPE string PERMISSIONS FULL;
-DEFINE FIELD expiresAt ON invitation TYPE datetime PERMISSIONS FULL;
-DEFINE FIELD inviterId ON invitation TYPE record<user> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD organizationId ON invitation TYPE record<organization> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD role ON invitation TYPE string PERMISSIONS FULL;
-DEFINE FIELD teamId ON invitation TYPE option<record<team>> REFERENCE ON DELETE CASCADE PERMISSIONS FULL;
-DEFINE FIELD token ON invitation TYPE string PERMISSIONS FULL;
+const adapter = adapterFunc(_auth.options);
+const schema = await adapter.createSchema!(_auth.options);
+console.log(schema.code);
 ```
 
 ## 🆓 Free SurrealDB Cloud Instance

--- a/db/surreal.ts
+++ b/db/surreal.ts
@@ -1,14 +1,8 @@
-import Surreal from "surrealdb";
+import Surreal, { ConnectOptions } from "surrealdb";
 
 // Define the database configuration interface
-interface DatabaseConfig {
-  url: string;
-  namespace: string;
-  database: string;
-  auth: {
-    username: string;
-    password: string;
-  };
+interface DatabaseConfig extends ConnectOptions {
+  url: Parameters<Surreal['connect']>[0];
 }
 
 // Define the default database configuration
@@ -29,11 +23,7 @@ export async function getDatabase(
   const db = new Surreal();
 
   try {
-    await db.connect(config.url, {
-      namespace: config.namespace,
-      database: config.database,
-      auth: { username: config.auth.username, password: config.auth.password },
-    });
+    await db.connect(config.url, config);
     return db;
   } catch (err) {
     console.error(

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@better-auth/utils": "^0.2.3",
-    "@types/bun": "^1.2.4",
-    "dayjs": "^1.11.13"
+    "@better-auth/utils": "^0.3.0",
+    "@types/bun": "^1.2.22",
+    "dayjs": "^1.11.18"
   },
   "peerDependencies": {
-    "better-auth": "^1.2.7",
+    "better-auth": "^1.3.11",
     "surrealdb": "1.3.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
   "name": "surrealdb-better-auth",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "author": {
     "name": "Necmettin Karakaya",
     "url": "https://github.com/necmttn",
     "email": "necmettin.karakaya@gmail.com",
     "github": "https://github.com/necmttn"
   },
+  "contributors": [{
+    "name": "Dylan Vanmali",
+    "url": "https://github.com/dvanmali",
+    "github": "https://github.com/dvanmali"
+  }],
   "description": "Better Auth adapter for SurrealDB",
   "keywords": [
     "adapter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,236 +1,128 @@
-import { generateId } from "better-auth";
-import { getAuthTables } from "better-auth/db";
-import type { Adapter, BetterAuthOptions, Where } from "better-auth/types";
-import { jsonify, type RecordId } from "surrealdb";
-import { Surreal } from "surrealdb";
-import { withApplyDefault } from "./utils";
-
-interface SurrealConfig {
-	address: string;
-	username: string;
-	password: string;
-	ns: string;
-	db: string;
-}
+import { getAuthTables } from 'better-auth/db';
+import { createAdapter } from "better-auth/adapters";
+import type { CreateCustomAdapter } from "better-auth/adapters";
+import type { BetterAuthOptions, Where } from 'better-auth/types';
+import { jsonify, RecordId, Surreal } from 'surrealdb';
 
 const createTransform = (options: BetterAuthOptions) => {
-	const schema = getAuthTables(options);
+    const schema = getAuthTables(options);
 
-	function transformSelect(select: string[], model: string): string[] {
-		if (!select || select.length === 0) return [];
-		return select.map((field) => getField(model, field));
-	}
+    function getField(model: string, field: string) {
+        if (field === "id") {
+            return field;
+        }
+        const f = schema[model].fields[field];
+        return f.fieldName || field;
+    }
 
-	function getField(model: string, field: string) {
-		if (field === "id") {
-			return field;
-		}
-		const f = schema[model].fields[field];
-		return f.fieldName || field;
-	}
-
-	return {
-		transformInput<T extends Record<string, unknown>>(
-			data: T,
-			model: string,
-			action: "update" | "create",
-		) {
-			const transformedData: Record<string, unknown> =
-				action === "update"
-					? {}
-					: {
-						id: options.advanced?.generateId
-							? options.advanced.generateId({ model })
-							: data.id || generateId(),
-					};
-
-			const fields = schema[model].fields;
-			for (const field in fields) {
-				const value = data[field];
-				if (value === undefined && !fields[field].defaultValue) {
-					continue;
-				}
-				transformedData[fields[field].fieldName || field] = withApplyDefault(
-					value,
-					{
-						...fields[field],
-						fieldName: fields[field].fieldName || field,
-					},
-					action,
-					model,
-				);
-			}
-			return transformedData;
-		},
-		transformOutput<T extends Record<string, unknown>>(
-			data: T,
-			model: string,
-			select: string[] = [],
-		) {
-			if (!data) return null;
-			const transformedData: Record<string, unknown> =
-				data.id || data._id
-					? select.length === 0 || select.includes("id")
-						? { id: jsonify(data.id) }
-						: {}
-					: {};
-			const tableSchema = schema[model].fields;
-			for (const key in tableSchema) {
-				if (select.length && !select.includes(key)) {
-					continue;
-				}
-				const field = tableSchema[key];
-				if (field) {
-					transformedData[key] = jsonify(data[field.fieldName || key]);
-				}
-			}
-			return transformedData as T;
-		},
-		convertWhereClause(where: Where[], model: string) {
-			return where
-				.map((clause) => {
-					const { field: _field, value, operator } = clause;
-					const field = getField(model, _field);
-					const v = value as unknown as RecordId;
-					const isRecordId = !!v.tb;
-					switch (operator) {
-						case "eq":
-							return field === "id" || isRecordId
-								? `${field} = ${jsonify(value)}`
-								: `${field} = '${jsonify(value)}'`;
-						case "in":
-							return `${field} IN [${jsonify(value)}]`;
-						case "contains":
-							return `${field} CONTAINS '${jsonify(value)}'`;
-						case "starts_with":
-							return `string::starts_with(${field},'${value}')`;
-						case "ends_with":
-							return `string::ends_with(${field},'${value}')`;
-						default:
-							if (field.endsWith("Id") || isRecordId || field === "id") {
-								return `${field} = ${jsonify(value)}`;
-							}
-							return `${field} = '${jsonify(value)}'`;
-					}
-				})
-				.join(" AND ");
-		},
-		transformSelect,
-		getField,
-	};
+    return {
+        convertWhereClause(where: Where[], model: string) {
+            return where.map(clause => {
+                const { field: field, value, operator } = clause;
+                switch (operator) {
+                    case "eq":
+                        return (field === 'id' || value instanceof RecordId)
+                            ? `${field} = ${jsonify(value)}`
+                            : `${field} = '${jsonify(value)}'`
+                    case "in":
+                        return `${field} IN [${jsonify(value)}]`;
+                    case "contains":
+                        return `${field} CONTAINS '${jsonify(value)}'`;
+                    case "starts_with":
+                        return `string::starts_with(${field},'${value}')`;
+                    case "ends_with":
+                        return `string::ends_with(${field},'${value}')`;
+                    default:
+                        return (field === 'id' || value instanceof RecordId)
+                            ? `${field} = ${jsonify(value)}`
+                            : `${field} = '${jsonify(value)}'`
+                }
+            }).join(' AND ');
+        },
+        getField,
+    };
 };
 
-export const surrealAdapter =
-	(db: Surreal, config?: SurrealConfig) =>
-		(options: BetterAuthOptions): Adapter => {
-			const { transformInput, transformOutput, convertWhereClause, getField } =
-				createTransform(options);
+export const surrealAdapter = (db: Surreal) => {
+    if (!db) {
+        throw new Error("SurrealDB adapter requires a SurrealDB client");
+    }
 
-			return {
-				id: "surreal",
-				create: async <T extends Record<string, unknown>, R = T>({
-					model,
-					data,
-				}: { model: string; data: T }) => {
-					const transformed = transformInput(data, model, "create");
-					const [result] = await db.create(model, transformed);
-					return transformOutput(result, model) as R;
-				},
-				findOne: async <T>({
-					model,
-					where,
-					select = [],
-				}: { model: string; where: Where[]; select?: string[] }) => {
+    return createAdapter({
+        config: {
+            adapterId: "surreal",
+            supportsBooleans: true,
+            supportsJSON: true,
+            supportsDates: true,
+            supportsNumericIds: true,
+        },
+        adapter: ({ options }) => {
+            const { convertWhereClause, getField } = createTransform(options);
+
+            return {
+                create: async ({ model, data }) => {
+                    const [result] = await db.create<any>(model, data);
+                    return result;
+                },
+                findOne: async ({ model, where, select = [] }) => {
+                    const whereClause = convertWhereClause(where, model);
+                    const selectClause = select.length > 0 && select.map((f) => getField(model, f)) || []
+                    const query = select.length > 0
+                        ? `SELECT ${selectClause.join(', ')} FROM ${model} WHERE ${whereClause} LIMIT 1`
+                        : `SELECT * FROM ${model} WHERE ${whereClause} LIMIT 1`;
+                    const [result] = await db.query<[any[]]>(query)
+                    return result[0];
+                },
+                findMany: async ({ model, where, sortBy, limit, offset }) => {
+                    let query = `SELECT * FROM ${model}`;
+                    if (where) {
+                        const whereClause = convertWhereClause(where, model);
+                        query += ` WHERE ${whereClause}`;
+                    }
+                    if (sortBy) {
+                        query += ` ORDER BY ${getField(model, sortBy.field)} ${sortBy.direction}`;
+                    }
+                    if (limit !== undefined) {
+                        query += ` LIMIT ${limit}`;
+                    }
+                    if (offset !== undefined) {
+                        query += ` START ${offset}`;
+                    }
+                    const [results] = await db.query<[any[]]>(query);
+                    return results;
+                },
+                count: async ({ model, where }) => {
+                    const whereClause = where ? convertWhereClause(where, model) : '';
+                    const query = `SELECT count(${whereClause}) FROM ${model} GROUP ALL`;
+                    const [result] = await db.query<[any[]]>(query);
+                    const res = result[0];
+                    return res.count;
+                },
+                update: async ({ model, where, update }) => {
 					const whereClause = convertWhereClause(where, model);
-					const selectClause =
-						(select.length > 0 && select.map((f) => getField(model, f))) || [];
-					const query =
-						select.length > 0
-							? `SELECT ${selectClause.join(", ")} FROM ${model} WHERE ${whereClause} LIMIT 1`
-							: `SELECT * FROM ${model} WHERE ${whereClause} LIMIT 1`;
-					const result = await db.query<[Record<string, unknown>[]]>(query);
-					return transformOutput(result[0][0], model, select) as T | null;
-				},
-				findMany: async <T>({
-					model,
-					where,
-					sortBy,
-					limit,
-					offset,
-				}: {
-					model: string;
-					where?: Where[];
-					sortBy?: { field: string; direction: "asc" | "desc" };
-					limit?: number;
-					offset?: number;
-				}) => {
-					let query = `SELECT * FROM ${model}`;
-					if (where) {
-						const whereClause = convertWhereClause(where, model);
-						query += ` WHERE ${whereClause}`;
-					}
-					if (sortBy) {
-						query += ` ORDER BY ${getField(model, sortBy.field)} ${sortBy.direction}`;
-					}
-					if (limit !== undefined) {
-						query += ` LIMIT ${limit}`;
-					}
-					if (offset !== undefined) {
-						query += ` START ${offset}`;
-					}
-					const [results] = await db.query<[Record<string, unknown>[]]>(query);
-					return results.map((record) => transformOutput(record, model) as T);
-				},
-				count: async ({ model, where }: { model: string; where?: Where[] }) => {
-					const whereClause = where ? convertWhereClause(where, model) : "";
-					const query = `SELECT count(${whereClause}) FROM ${model} GROUP ALL`;
-					const [result] = await db.query<[Record<string, unknown>[]]>(query);
-					const res = result[0];
-					return Number(res.count);
-				},
-				update: async <T extends Record<string, unknown>, R = T>({
-					model,
-					where,
-					update,
-				}: { model: string; where: Where[]; update: T }) => {
-					const whereClause = convertWhereClause(where, model);
-					const transformedUpdate = transformInput(update, model, "update");
-					const [result] = await db.query<[Record<string, unknown>[]]>(
-						`UPDATE ${model} MERGE $transformedUpdate WHERE ${whereClause}`,
+					const [result] = await db.query<[any[]]>(
+						`UPDATE ${model} MERGE $update WHERE ${whereClause}`,
 						{
-							transformedUpdate,
+							update,
 						},
 					);
-					return transformOutput(result[0], model) as R;
+					return result[0];
 				},
-				delete: async ({ model, where }: { model: string; where: Where[] }) => {
-					const whereClause = convertWhereClause(where, model);
-					await db.query(`DELETE FROM ${model} WHERE ${whereClause}`);
-				},
-				deleteMany: async ({
-					model,
-					where,
-				}: { model: string; where: Where[] }) => {
-					const whereClause = convertWhereClause(where, model);
-					const [result] = await db.query<[Record<string, unknown>[]]>(
-						`DELETE FROM ${model} WHERE ${whereClause}`,
-					);
-					return result.length;
-				},
-				updateMany: async <T extends Record<string, unknown>, R = T>({
-					model,
-					where,
-					update,
-				}: { model: string; where: Where[]; update: T }) => {
-					const whereClause = convertWhereClause(where, model);
-					const transformedUpdate = transformInput(update, model, "update");
-					const [result] = await db.query<[Record<string, unknown>[]]>(
-						`UPDATE ${model} MERGE $transformedUpdate WHERE ${whereClause}`,
-						{
-							transformedUpdate,
-						},
-					);
-					return transformOutput(result[0], model) as R;
-				},
-			} satisfies Adapter;
-		};
+                delete: async ({ model, where }) => {
+                    const whereClause = convertWhereClause(where, model);
+                    await db.query(`DELETE FROM ${model} WHERE ${whereClause}`);
+                },
+                deleteMany: async ({ model, where }) => {
+                    const whereClause = convertWhereClause(where, model);
+                    const [result] = await db.query<[any[]]>(`DELETE FROM ${model} WHERE ${whereClause}`);
+                    return result.length;
+                },
+                updateMany: async ({ model, where, update }) => {
+                    const whereClause = convertWhereClause(where, model);
+                    const [result] = await db.query<[any[]]>(`UPDATE ${model} MERGE ${JSON.stringify(update)} WHERE ${whereClause}`);
+                    return result[0];
+                },
+            } satisfies ReturnType<CreateCustomAdapter>
+        },
+    })
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,50 @@
+import type { FieldType} from 'better-auth/db';
 import { getAuthTables } from 'better-auth/db';
 import { createAdapter } from "better-auth/adapters";
 import type { CreateCustomAdapter } from "better-auth/adapters";
 import type { BetterAuthOptions, Where } from 'better-auth/types';
-import { jsonify, RecordId, Surreal } from 'surrealdb';
+import type { Surreal } from 'surrealdb';
+import { jsonify, RecordId, StringRecordId } from 'surrealdb';
+import { operatorMap, typeMap } from './utils';
 
-const createTransform = (options: BetterAuthOptions) => {
+export interface SurrealBetterAuthConfig {
+    /**
+     * Enable fields with record type. Otherwise, field type is string.
+     *
+     * Utilizing this may require you to convert string fields
+     * to record types beforehand as `generate` does not perform
+     * this conversion for you.
+     *
+     * @default false
+     */
+    enableRecords?: boolean
+    /**
+     * Settings pertaining to schema creation and likewise
+     * the better-auth cli `generate` function
+     */
+	generate?: {
+		/**
+		 * Add the overwrite clause on all statements
+		 */
+		overwrite?: boolean
+		/**
+		 * Disables "ON DELETE" record references functionality
+		 * such as when surreal<=v2. Only valid when
+         * enableRecords is true.
+		 *
+		 * @default false
+		 */
+		disableOnDeleteReference?: boolean
+		/**
+		 * Rounds default times using time::
+		 * 
+		 * @default 's' - seconds
+		 */
+		roundDefaultTime?: 's' | 'ms' | false
+	}
+}
+
+const createTransform = (options: BetterAuthOptions, config?: SurrealBetterAuthConfig) => {
     const schema = getAuthTables(options);
 
     function getField(model: string, field: string) {
@@ -17,33 +57,40 @@ const createTransform = (options: BetterAuthOptions) => {
 
     return {
         convertWhereClause(where: Where[], model: string) {
-            return where.map(clause => {
-                const { field: field, value, operator } = clause;
+            return where.map((clause, index) => {
+                const { field: field, value, operator, connector } = clause;
+                const isRecordField =
+                    field === 'id'
+                    || value instanceof RecordId
+                    || (field.endsWith('Id') && config?.enableRecords)
+                let str!: string
                 switch (operator) {
-                    case "eq":
-                        return (field === 'id' || value instanceof RecordId)
-                            ? `${field} = ${jsonify(value)}`
-                            : `${field} = '${jsonify(value)}'`
                     case "in":
-                        return `${field} IN [${jsonify(value)}]`;
-                    case "contains":
-                        return `${field} CONTAINS '${jsonify(value)}'`;
+                        str = `${field} IN [${jsonify(value)}]`;
+                        break;
                     case "starts_with":
-                        return `string::starts_with(${field},'${value}')`;
+                        str = `string::starts_with(${field},'${value}')`;
+                        break;
                     case "ends_with":
-                        return `string::ends_with(${field},'${value}')`;
+                        str = `string::ends_with(${field},'${value}')`;
+                        break;
                     default:
-                        return (field === 'id' || value instanceof RecordId)
-                            ? `${field} = ${jsonify(value)}`
-                            : `${field} = '${jsonify(value)}'`
+                        str = isRecordField
+                            ? `${field} ${operatorMap[operator ?? "eq"]} ${jsonify(value)}`
+                            : `${field} ${operatorMap[operator ?? "eq"]} '${jsonify(value)}'`
+                        break;
                 }
-            }).join(' AND ');
+                if (index < where.length - 1) {
+                    str += ` ${connector ?? 'AND'} `
+                }
+                return str
+            }).join('');
         },
         getField,
     };
 };
 
-export const surrealAdapter = (db: Surreal) => {
+export const surrealAdapter = (db: Surreal, config?: SurrealBetterAuthConfig) => {
     if (!db) {
         throw new Error("SurrealDB adapter requires a SurrealDB client");
     }
@@ -55,9 +102,28 @@ export const surrealAdapter = (db: Surreal) => {
             supportsJSON: true,
             supportsDates: true,
             supportsNumericIds: true,
+            disableIdGeneration: true,
+            customTransformInput: ({ field, data }) => {
+                // Attempt to transform a string to a RecordId
+                if (
+                    config?.enableRecords
+                    && (field === 'id' || field.endsWith('Id'))
+                    && typeof data === 'string'
+                ) {
+                    data = new StringRecordId(data)
+                }
+                return data
+            },
+            customTransformOutput: ({ field, data }) => {
+                // Convert RecordId to String
+                if (data instanceof RecordId) {
+                    data = data.toString()
+                }
+                return data
+            }
         },
         adapter: ({ options }) => {
-            const { convertWhereClause, getField } = createTransform(options);
+            const { convertWhereClause, getField } = createTransform(options, config);
 
             return {
                 create: async ({ model, data }) => {
@@ -65,13 +131,28 @@ export const surrealAdapter = (db: Surreal) => {
                     return result;
                 },
                 findOne: async ({ model, where, select = [] }) => {
-                    const whereClause = convertWhereClause(where, model);
+                    const idWhereIndex = where.findIndex((val) => val.field === "id")
                     const selectClause = select.length > 0 && select.map((f) => getField(model, f)) || []
-                    const query = select.length > 0
-                        ? `SELECT ${selectClause.join(', ')} FROM ${model} WHERE ${whereClause} LIMIT 1`
-                        : `SELECT * FROM ${model} WHERE ${whereClause} LIMIT 1`;
-                    const [result] = await db.query<[any[]]>(query)
-                    return result[0];
+
+                    // Search by id
+                    if (idWhereIndex >= 0) {
+                        const [id] = where.splice(idWhereIndex, 1)
+                        const whereClause = convertWhereClause(where, model);
+                        const query = select.length > 0
+                            ? `SELECT ${selectClause.join(', ')} FROM ONLY ${id.value} ${whereClause.length ? `WHERE ${whereClause}` : ''}`
+                            : `SELECT * FROM ONLY ${id.value} ${whereClause.length ? `WHERE ${whereClause}` : ''}`;
+                        const [result] = await db.query<[any]>(query)
+                        return typeof result === 'object' ? result : null
+                    }
+                    // Search by where
+                    else {
+                        const whereClause = convertWhereClause(where, model);
+                        const query = select.length > 0
+                            ? `SELECT ${selectClause.join(', ')} FROM ${model} WHERE ${whereClause} LIMIT 1`
+                            : `SELECT * FROM ${model} WHERE ${whereClause} LIMIT 1`;
+                        const [result] = await db.query<[any[]]>(query)
+                        return result[0];
+                    }
                 },
                 findMany: async ({ model, where, sortBy, limit, offset }) => {
                     let query = `SELECT * FROM ${model}`;
@@ -99,28 +180,127 @@ export const surrealAdapter = (db: Surreal) => {
                     return res.count;
                 },
                 update: async ({ model, where, update }) => {
-					const whereClause = convertWhereClause(where, model);
-					const [result] = await db.query<[any[]]>(
-						`UPDATE ${model} MERGE $update WHERE ${whereClause}`,
-						{
-							update,
-						},
-					);
-					return result[0];
+                    const idWhereIndex = where.findIndex((val) => val.field === "id")
+                    if (idWhereIndex > 0) {
+                        const [id] = where.splice(idWhereIndex, 1)
+                        const whereClause = convertWhereClause(where, model);
+                        const query = `UPDATE ONLY ${id.value} MERGE $update ${whereClause.length ? `WHERE ${whereClause}` : ''}`
+                        const [result] = await db.query<[any]>(query, {
+                            update,
+                        })
+                        return typeof result === 'object' ? result : null
+                    } else {
+                        const whereClause = convertWhereClause(where, model);
+                        const query = `UPDATE ${model} MERGE $update WHERE ${whereClause}`
+                        const [result] = await db.query<[any[]]>(query, {
+                            update,
+                        });
+                        return result[0];
+                    }
 				},
                 delete: async ({ model, where }) => {
-                    const whereClause = convertWhereClause(where, model);
-                    await db.query(`DELETE FROM ${model} WHERE ${whereClause}`);
+                    const idWhereIndex = where.findIndex((val) => val.field === "id")
+                    if (idWhereIndex > 0) {
+                        const [id] = where.splice(idWhereIndex, 1)
+                        const whereClause = convertWhereClause(where, model);
+                        const query = `DELETE ONLY ${id.value} ${whereClause.length ? `WHERE ${whereClause}` : ''} RETURN BEFORE`
+                        await db.query<[any]>(query)
+                    } else {
+                        const whereClause = convertWhereClause(where, model);
+                        const query = `DELETE ${model} WHERE ${whereClause} RETURN NONE`
+                        await db.query<[any[]]>(query);
+                    }
                 },
                 deleteMany: async ({ model, where }) => {
                     const whereClause = convertWhereClause(where, model);
-                    const [result] = await db.query<[any[]]>(`DELETE FROM ${model} WHERE ${whereClause}`);
+                    const [result] = await db.query<[any[]]>(`DELETE FROM ${model} WHERE ${whereClause} RETURN BEFORE`);
                     return result.length;
                 },
                 updateMany: async ({ model, where, update }) => {
                     const whereClause = convertWhereClause(where, model);
                     const [result] = await db.query<[any[]]>(`UPDATE ${model} MERGE ${JSON.stringify(update)} WHERE ${whereClause}`);
                     return result[0];
+                },
+                createSchema: async ({ file, tables }) => {
+                    if (file && !file?.endsWith('.surql')) {
+                        throw Error("output file type must be .surql")
+                    }
+                    let code = ''
+                    const overwrite = config?.generate?.overwrite ? "OVERWRITE " : ""
+                    const defaultTimeNow = config?.generate?.roundDefaultTime === false
+                        ? `time::now()`
+                        : `time::round(time::now(), 1${config?.generate?.roundDefaultTime ?? 's'})`
+
+                    for (const [tablekey, table] of Object.entries(tables)) {
+                        const tableName = table.modelName ?? tablekey
+                        code += `DEFINE TABLE ${overwrite}${tableName} SCHEMAFULL;\n`
+
+                        for (const [fieldkey, field] of Object.entries(table.fields)) {
+                            const fieldName = field.fieldName ?? fieldkey
+                            const typeKey = Array.isArray(field.type) ? `${field.type[0]}[]` as FieldType : field.type;
+                            let type = typeMap[typeKey as string] ?? "any"
+
+                            if (
+                                config?.enableRecords
+                                && field.references
+                                && field.references.field === 'id'
+                            ) {
+                                type = (typeKey as string).endsWith("[]")
+                                    ? `record<array<${field.references.model}>>`
+                                    : `record<${field.references.model}>`
+                            }
+
+                            if (!field.required && type !== "any") {
+                                type = `option<${type}>`
+                            }
+
+                            let fieldDefault = typeof field.defaultValue === "function" ? field.defaultValue() : field.defaultValue;
+                            let defaultStr: string | undefined = undefined
+                            if (fieldDefault !== undefined) {
+                                if (fieldkey?.endsWith('At')) {
+                                    fieldDefault = defaultTimeNow
+                                    defaultStr = fieldDefault ? ` VALUE ${fieldDefault}${
+                                        fieldkey === 'createdAt' ? " READONLY" : ""
+                                    }` : ""
+                                } else {
+                                    defaultStr = fieldDefault !== undefined ? ` DEFAULT ${fieldDefault}` : ""
+                                }
+                            }
+
+                            if (
+                                config?.enableRecords
+                                && field.references?.onDelete
+                                && !config?.generate?.disableOnDeleteReference
+                            ) {
+                                switch (field.references.onDelete) {
+                                    case 'set null':
+                                        type += ` REFERENCE ON DELETE UNSET`
+                                        break;
+                                    case 'no action':
+                                        type += ` REFERENCE ON DELETE IGNORE`
+                                        break;
+                                    case 'restrict':
+                                        type += ` REFERENCE ON DELETE REJECT`
+                                        break;
+                                    case 'set default':
+                                        type += ` REFERENCE ON DELETE THEN $value = ${fieldDefault}`
+                                        break;
+                                    case 'cascade':
+                                    default:
+                                        type += ` REFERENCE ON DELETE CASCADE`
+                                        break;
+                                }
+                            }
+
+                            code += `DEFINE FIELD ${overwrite}${fieldName} ON TABLE ${tableName} TYPE ${type}${defaultStr ?? ""};\n`
+                        }
+
+                        code += `\n`
+                    }
+                    return {
+                        code,
+                        path: file ?? 'auth.surql',
+                    }
                 },
             } satisfies ReturnType<CreateCustomAdapter>
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,3 @@
-import type { FieldAttribute } from "better-auth/db";
 import type { Where } from "better-auth/types";
 
 export const operatorMap: Record<Required<Where>['operator'], string | null> = {
@@ -10,6 +9,7 @@ export const operatorMap: Record<Required<Where>['operator'], string | null> = {
     "gte": ">=",
     "contains": "CONTAINS",
     "in": "IN",
+    "not_in": "NOTINSIDE",
     // not operators but functions
     "starts_with": null,
     "ends_with": null,
@@ -22,4 +22,5 @@ export const typeMap: Record<string, string> = {
     date: "datetime",
     "number[]": "array<number>",
     "string[]": "array<string>",
+    json: "array | object"
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,30 +23,3 @@ export const typeMap: Record<string, string> = {
     "number[]": "array<number>",
     "string[]": "array<string>",
 }
-
-function isDateString(dateString: string) {
-    const date = new Date(dateString);
-    return !isNaN(date.getTime());
-}
-
-export function withApplyDefault(
-    value: any,
-    field: FieldAttribute,
-    action: "create" | "update",
-) {
-    if (action === "update") {
-        return value;
-    }
-    if (value === undefined || value === null) {
-        if (field.defaultValue) {
-            if (typeof field.defaultValue === "function") {
-                return field.defaultValue();
-            }
-            return field.defaultValue;
-        }
-    }
-    if (typeof value === 'string' && isDateString(value)) {
-        return new Date(value);
-    }
-    return value;
-}

--- a/tests/runAdapterTest.ts
+++ b/tests/runAdapterTest.ts
@@ -1,6 +1,6 @@
 // Based on packages/better-auth/src/adapters/test.ts
 
-import { generateId } from "better-auth";
+import { generateId, Session } from "better-auth";
 import type { Adapter, BetterAuthOptions, User } from "better-auth/types";
 import { expect, test } from "bun:test";
 import { RecordId } from "surrealdb";
@@ -13,19 +13,20 @@ interface AdapterTestOptions {
 
 export async function runAdapterTest(opts: AdapterTestOptions) {
 	const adapter = await opts.getAdapter();
-	const user = {
+	const user: User = {
 		id: "1",
-		name: "user",
-		email: "user@email.com",
+		name: "user1",
+		email: "user1@email.com",
 		emailVerified: true,
 		createdAt: new Date(),
 		updatedAt: new Date(),
 	};
 
 	test("create model", async () => {
-		const res = await adapter.create({
+		const res = await adapter.create<User>({
 			model: "user",
 			data: user,
+			forceAllowId: true,
 		});
 
 		expect({
@@ -122,6 +123,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const user = await adapter.create<User>({
 			model: "user",
 			data: {
+				// @ts-expect-error forceAllowId: true
 				id: "2",
 				name: "user2",
 				email: "test@email.com",
@@ -129,6 +131,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
+			forceAllowId: true,
 		});
 		const res = await adapter.findMany({
 			model: "user",
@@ -146,13 +149,15 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const newUser = await adapter.create<User>({
 			model: "user",
 			data: {
+				// @ts-expect-error forceAllowId: true
 				id: "3",
-				name: "user",
-				email: "test-email2@email.com",
+				name: "user3",
+				email: "user3@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
+			forceAllowId: true,
 		});
 		const res = await adapter.findMany({
 			model: "user",
@@ -168,20 +173,23 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 	});
 
 	test("should work with reference fields", async () => {
-		const user = await adapter.create<{ id: string } & Record<string, any>>({
+		const user = await adapter.create<User>({
 			model: "user",
 			data: {
+				// @ts-expect-error forceAllowId: true
 				id: "4",
-				name: "user",
-				email: "my-email@email.com",
+				name: "user4",
+				email: "user4@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
+			forceAllowId: true,
 		});
-		await adapter.create({
+		await adapter.create<Session>({
 			model: "session",
 			data: {
+				// @ts-expect-error forceAllowId: true
 				id: "1",
 				token: generateId(),
 				createdAt: new Date(),
@@ -189,6 +197,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 				userId: user.id,
 				expiresAt: new Date(),
 			},
+			forceAllowId: true,
 		});
 		const res = await adapter.findOne({
 			model: "session",
@@ -205,9 +214,10 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 	});
 
 	test("should find many with sortBy", async () => {
-		await adapter.create({
+		await adapter.create<User>({
 			model: "user",
 			data: {
+				// @ts-expect-error forceAllowId: true
 				id: "5",
 				name: "a",
 				email: "a@email.com",
@@ -215,6 +225,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
+			forceAllowId: true,
 		});
 		const res = await adapter.findMany<User>({
 			model: "user",
@@ -308,9 +319,10 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 
 	test("should delete many", async () => {
 		for (const id of ["to-be-delete1", "to-be-delete2", "to-be-delete3"]) {
-			await adapter.create({
+			await adapter.create<User>({
 				model: "user",
 				data: {
+					// @ts-expect-error: forceAllowId: true
 					id,
 					name: "to-be-deleted",
 					email: `email@test-${id}.com`,
@@ -318,6 +330,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 					createdAt: new Date(),
 					updatedAt: new Date(),
 				},
+				forceAllowId: true,
 			});
 		}
 		const findResFirst = await adapter.findMany({
@@ -431,29 +444,4 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		});
 		expect(res.length).toBe(1);
 	});
-
-	test.skipIf(opts.skipGenerateIdTest || false)(
-		"should prefer generateId if provided",
-		async () => {
-			const customAdapter = await opts.getAdapter({
-				advanced: {
-					generateId: () => 'mocked-id',
-				},
-			});
-
-			const res = await customAdapter.create({
-				model: "user",
-				data: {
-					id: "1",
-					name: "user4",
-					email: "user4@email.com",
-					emailVerified: true,
-					createdAt: new Date(),
-					updatedAt: new Date(),
-				},
-			});
-			expect(res.id).toBeInstanceOf(RecordId);
-			expect((res.id as unknown as RecordId).id).toBe('mocked-id');
-		},
-	);
 }

--- a/tests/runAdapterTest.ts
+++ b/tests/runAdapterTest.ts
@@ -13,7 +13,7 @@ interface AdapterTestOptions {
 export async function runAdapterTest(opts: AdapterTestOptions) {
 	const adapter = await opts.getAdapter();
 	const user: User = {
-		id: "1",
+		id: "user:1",
 		name: "user1",
 		email: "user1@email.com",
 		emailVerified: true,
@@ -165,24 +165,25 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 	});
 
 	test("should work with reference fields", async () => {
+		const now = Date.now()
 		const user = await adapter.create<User>({
 			model: "user",
 			data: {
 				name: "user4",
 				email: "user4@email.com",
 				emailVerified: true,
-				createdAt: new Date(),
-				updatedAt: new Date(),
+				createdAt: new Date(now),
+				updatedAt: new Date(now),
 			},
 		});
 		await adapter.create<Session>({
 			model: "session",
 			data: {
 				token: generateId(),
-				createdAt: new Date(),
-				updatedAt: new Date(),
+				createdAt: new Date(now),
+				updatedAt: new Date(now),
 				userId: user.id,
-				expiresAt: new Date(),
+				expiresAt: new Date(now + 10 * 60 * 1000),
 			},
 		});
 		const res = await adapter.findOne({
@@ -425,18 +426,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		});
 		expect(res.length).toBe(1);
 	});
-	test("should search users with endsWith", async () => {
-		const resNum = await adapter.findMany({
-			model: "session",
-			where: [
-				{
-					field: "expiresAt",
-					operator: "gte",
-					value: Date.now(),
-				},
-			],
-		});
-		expect(resNum.length).toBe(1);
+	test("should search for valid sessions", async () => {
 		const resDate = await adapter.findMany({
 			model: "session",
 			where: [

--- a/tests/runAdapterTest.ts
+++ b/tests/runAdapterTest.ts
@@ -425,4 +425,28 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		});
 		expect(res.length).toBe(1);
 	});
+	test("should search users with endsWith", async () => {
+		const resNum = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "expiresAt",
+					operator: "gte",
+					value: Date.now(),
+				},
+			],
+		});
+		expect(resNum.length).toBe(1);
+		const resDate = await adapter.findMany({
+			model: "session",
+			where: [
+				{
+					field: "expiresAt",
+					operator: "gte",
+					value: new Date(),
+				},
+			],
+		});
+		expect(resDate.length).toBe(1);
+	});
 }

--- a/tests/runAdapterTest.ts
+++ b/tests/runAdapterTest.ts
@@ -3,12 +3,11 @@
 import { generateId, Session } from "better-auth";
 import type { Adapter, BetterAuthOptions, User } from "better-auth/types";
 import { expect, test } from "bun:test";
-import { RecordId } from "surrealdb";
+
 interface AdapterTestOptions {
 	getAdapter: (
 		customOptions?: Omit<BetterAuthOptions, "database">,
-	) => Promise<Adapter>;
-	skipGenerateIdTest?: boolean;
+	) => Promise<Adapter>
 }
 
 export async function runAdapterTest(opts: AdapterTestOptions) {
@@ -26,7 +25,6 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const res = await adapter.create<User>({
 			model: "user",
 			data: user,
-			forceAllowId: true,
 		});
 
 		expect({
@@ -123,15 +121,12 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const user = await adapter.create<User>({
 			model: "user",
 			data: {
-				// @ts-expect-error forceAllowId: true
-				id: "2",
 				name: "user2",
 				email: "test@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
-			forceAllowId: true,
 		});
 		const res = await adapter.findMany({
 			model: "user",
@@ -149,15 +144,12 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const newUser = await adapter.create<User>({
 			model: "user",
 			data: {
-				// @ts-expect-error forceAllowId: true
-				id: "3",
 				name: "user3",
 				email: "user3@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
-			forceAllowId: true,
 		});
 		const res = await adapter.findMany({
 			model: "user",
@@ -176,28 +168,22 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		const user = await adapter.create<User>({
 			model: "user",
 			data: {
-				// @ts-expect-error forceAllowId: true
-				id: "4",
 				name: "user4",
 				email: "user4@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
-			forceAllowId: true,
 		});
 		await adapter.create<Session>({
 			model: "session",
 			data: {
-				// @ts-expect-error forceAllowId: true
-				id: "1",
 				token: generateId(),
 				createdAt: new Date(),
 				updatedAt: new Date(),
 				userId: user.id,
 				expiresAt: new Date(),
 			},
-			forceAllowId: true,
 		});
 		const res = await adapter.findOne({
 			model: "session",
@@ -217,15 +203,12 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 		await adapter.create<User>({
 			model: "user",
 			data: {
-				// @ts-expect-error forceAllowId: true
-				id: "5",
 				name: "a",
 				email: "a@email.com",
 				emailVerified: true,
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			},
-			forceAllowId: true,
 		});
 		const res = await adapter.findMany<User>({
 			model: "user",
@@ -318,19 +301,16 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 	});
 
 	test("should delete many", async () => {
-		for (const id of ["to-be-delete1", "to-be-delete2", "to-be-delete3"]) {
+		for (const id of [1,2,3]) {
 			await adapter.create<User>({
 				model: "user",
 				data: {
-					// @ts-expect-error: forceAllowId: true
-					id,
 					name: "to-be-deleted",
 					email: `email@test-${id}.com`,
 					emailVerified: true,
 					createdAt: new Date(),
 					updatedAt: new Date(),
 				},
-				forceAllowId: true,
 			});
 		}
 		const findResFirst = await adapter.findMany({
@@ -343,7 +323,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 			],
 		});
 		expect(findResFirst.length).toBe(3);
-		await adapter.deleteMany({
+		const deleted = await adapter.deleteMany({
 			model: "user",
 			where: [
 				{
@@ -352,6 +332,7 @@ export async function runAdapterTest(opts: AdapterTestOptions) {
 				},
 			],
 		});
+		expect(deleted).toBe(findResFirst.length)
 		const findRes = await adapter.findMany({
 			model: "user",
 			where: [

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,0 +1,300 @@
+import { afterAll, beforeAll, describe, expect, Test, test } from "bun:test";
+import { surrealAdapter, SurrealBetterAuthConfig } from "../src";
+import { getDatabase } from "../db/surreal";
+import { BetterAuthOptions } from "better-auth/types";
+import { runAdapterTest } from "./runAdapterTest";
+import Surreal from "surrealdb";
+
+// Autocleans after each test, if you are debugging, you may wish this is false
+const cleanAfterAll = true;
+
+function getTestSchemaAdapter(db: Surreal, config?: SurrealBetterAuthConfig) {
+  const adapterFunc = surrealAdapter(db, config);
+  const opts: BetterAuthOptions = {
+    user: {
+      fields: {
+        email: "email_address",
+      },
+      additionalFields: {
+        test: {
+          type: "string",
+          defaultValue: "test",
+        },
+      },
+    },
+    session: {
+      modelName: "sessions",
+    },
+  }
+  const adapter = adapterFunc(opts)
+
+  if (!adapter.createSchema) {
+    throw new Error("create schema should be defined");
+  }
+
+  return {
+    adapter,
+    opts,
+  }
+}
+
+describe("no config", async () => {
+  const database = `better_auth_test_no_config`
+  const db = await getDatabase({
+    url: "http://127.0.0.1:8000/rpc",
+    namespace: "better_auth",
+    database,
+    auth: {
+      username: "root",
+      password: "root",
+    },
+  });
+  const { adapter, opts } = getTestSchemaAdapter(db);
+
+  beforeAll(async () => {
+    await db.query(`
+      DEFINE NAMESPACE IF NOT EXISTS better_auth;
+      REMOVE DATABASE IF EXISTS ${database};
+      DEFINE DATABASE IF NOT EXISTS ${database};
+    `);
+  });
+
+  afterAll(async () => {
+    if (cleanAfterAll) {
+      await db.query(`REMOVE DATABASE IF EXISTS ${database};`)
+    }
+  })
+
+  test("schema generation", async () => {
+    const schema = await adapter.createSchema!(opts)
+
+    expect(schema.code.length).toBeGreaterThan(0);
+    expect(schema.code).toContain("DEFINE FIELD email_address ON TABLE user");
+    expect(schema.code).toContain("DEFINE FIELD test ON TABLE user");
+    expect(schema.code).toContain("DEFINE TABLE sessions");
+
+    // Add schema to db
+    await db.query(schema.code)
+  })
+
+  // Adapter should still run
+  await runAdapterTest({
+    getAdapter: async () => adapter
+  })
+});
+
+describe("generate - overwrite", async () => {
+  const database = `better_auth_test_overwrite_schema`
+  const db = await getDatabase({
+    url: "http://127.0.0.1:8000/rpc",
+    namespace: "better_auth",
+    database,
+    auth: {
+      username: "root",
+      password: "root",
+    },
+  });
+
+  beforeAll(async () => {
+    await db.query(`
+      DEFINE NAMESPACE IF NOT EXISTS better_auth;
+      REMOVE DATABASE IF EXISTS ${database};
+      DEFINE DATABASE IF NOT EXISTS ${database};
+    `);
+  });
+
+  afterAll(async () => {
+    if (cleanAfterAll) {
+      await db.query(`REMOVE DATABASE IF EXISTS ${database};`)
+    }
+  })
+
+  test("schema without overwrite", async () => {
+    const { adapter, opts } = getTestSchemaAdapter(db);
+
+    const schema = await adapter.createSchema!(opts)
+
+    expect(schema.code.length).toBeGreaterThan(0);
+    expect(schema.code).not.toContain("DEFINE FIELD OVERWRITE");
+    expect(schema.code).not.toContain("DEFINE TABLE OVERWRITE");
+
+    await db.query(schema.code);
+  })
+
+  test("schema overwriten", async () => {
+    const { adapter, opts } = getTestSchemaAdapter(db, {
+      generate: {
+        overwrite: true,
+      }
+    });
+
+    const schema = await adapter.createSchema!(opts)
+
+    expect(schema.code.length).toBeGreaterThan(0);
+    const pattern = /^(?!.*\bDEFINE (FIELD|TABLE)\b(?! OVERWRITE)).*\bDEFINE (FIELD|TABLE) OVERWRITE\b.*$/s;
+    expect(pattern.test(schema.code)).toBeTrue();
+
+    // Shall overwrite the schema in test 1
+    await db.query(schema.code);
+  })
+});
+
+describe("generate - enable records", async () => {
+  const database = `better_auth_test_enableRecords`
+  const db = await getDatabase({
+    url: "http://127.0.0.1:8000/rpc",
+    namespace: "better_auth",
+    database,
+    auth: {
+      username: "root",
+      password: "root",
+    },
+  });
+  const { adapter, opts } = getTestSchemaAdapter(db, {
+    enableRecords: true,
+  });
+
+  beforeAll(async () => {
+    await db.query(`
+      DEFINE NAMESPACE IF NOT EXISTS better_auth;
+      REMOVE DATABASE IF EXISTS ${database};
+      DEFINE DATABASE IF NOT EXISTS ${database};
+    `);
+  });
+
+  afterAll(async () => {
+    if (cleanAfterAll) {
+      await db.query(`REMOVE DATABASE IF EXISTS ${database};`)
+    }
+  })
+
+  test("schema generation", async () => {
+    const schema = await adapter.createSchema!(opts)
+
+    expect(schema.code.length).toBeGreaterThan(0);
+    expect(schema.code).toContain("DEFINE FIELD email_address ON TABLE user");
+    expect(schema.code).toContain("DEFINE FIELD test ON TABLE user");
+    expect(schema.code).toContain("DEFINE TABLE sessions");
+
+    // Add schema to db
+    await db.query(schema.code)
+  })
+
+  // Adapter should still run
+  await runAdapterTest({
+    getAdapter: async () => adapter
+  })
+});
+
+describe("generate - enable records, disable on delete references", async () => {
+  const database = `better_auth_test_enableRecords_disableOnDeleteReference`
+  const db = await getDatabase({
+    url: "http://127.0.0.1:8000/rpc",
+    namespace: "better_auth",
+    database,
+    auth: {
+      username: "root",
+      password: "root",
+    },
+  });
+  const { adapter, opts } = getTestSchemaAdapter(db, {
+    enableRecords: true,
+    generate: {
+      disableOnDeleteReference: true,
+    }
+  });
+
+  beforeAll(async () => {
+    await db.query(`
+      DEFINE NAMESPACE IF NOT EXISTS better_auth;
+      REMOVE DATABASE IF EXISTS ${database};
+      DEFINE DATABASE IF NOT EXISTS ${database};
+    `);
+  });
+
+  afterAll(async () => {
+    if (cleanAfterAll) {
+      await db.query(`REMOVE DATABASE IF EXISTS ${database};`)
+    }
+  })
+
+  test("schema generation", async () => {
+    const schema = await adapter.createSchema!(opts)
+
+    expect(schema.code.length).toBeGreaterThan(0);
+    expect(schema.code).toContain("DEFINE FIELD email_address ON TABLE user");
+    expect(schema.code).toContain("DEFINE FIELD test ON TABLE user");
+    expect(schema.code).toContain("DEFINE TABLE sessions");
+
+    // Add schema to db
+    await db.query(schema.code)
+  })
+
+  // Adapter should still run
+  await runAdapterTest({
+    getAdapter: async () => adapter
+  })
+});
+
+describe.each([
+  's', 'ms', false
+])("generate - roundDefaultTime %p", async (roundDefaultTime) => {
+  const database = `better_auth_test_roundDefaultTime_${roundDefaultTime.toString()}`
+  const db = await getDatabase({
+    url: "http://127.0.0.1:8000/rpc",
+    namespace: "better_auth",
+    database,
+    auth: {
+      username: "root",
+      password: "root",
+    },
+  });
+  const { adapter, opts } = getTestSchemaAdapter(db, {
+    generate: {
+      roundDefaultTime: roundDefaultTime as 's' | 'ms' | false | undefined,
+    }
+  });
+
+  beforeAll(async () => {
+    await db.query(`
+      DEFINE NAMESPACE IF NOT EXISTS better_auth;
+      REMOVE DATABASE IF EXISTS ${database};
+      DEFINE DATABASE IF NOT EXISTS ${database};
+    `);
+  });
+
+  afterAll(async () => {
+    if (cleanAfterAll) {
+      await db.query(`REMOVE DATABASE IF EXISTS ${database};`)
+    }
+  })
+
+  test("schema generation", async () => {
+    const schema = await adapter.createSchema!(opts)
+
+    if (roundDefaultTime) {
+      expect(schema.code).toContain(`time::round(time::now(), 1${roundDefaultTime})`)
+    } else {
+      expect(schema.code).toContain("time::now()")
+    }
+
+    // Check createdAt, updatedAt, and expiresAt 
+    if (roundDefaultTime === false) {
+      expect(schema.code).toContain("DEFINE FIELD createdAt ON TABLE user TYPE datetime VALUE time::now() READONLY;");
+      expect(schema.code).toContain("DEFINE FIELD updatedAt ON TABLE user TYPE datetime VALUE time::now();");
+      expect(schema.code).toContain("DEFINE FIELD expiresAt ON TABLE sessions TYPE datetime;"); // not applied
+    } else {
+      expect(schema.code).toContain(`DEFINE FIELD createdAt ON TABLE user TYPE datetime VALUE time::round(time::now(), 1${roundDefaultTime ?? 's'}) READONLY;`);
+      expect(schema.code).toContain(`DEFINE FIELD updatedAt ON TABLE user TYPE datetime VALUE time::round(time::now(), 1${roundDefaultTime ?? 's'});`);
+      expect(schema.code).toContain(`DEFINE FIELD expiresAt ON TABLE sessions TYPE datetime;`); // not applied
+    }
+
+    // Add schema to db
+    await db.query(schema.code)
+  })
+
+  // Adapter should still run
+  await runAdapterTest({
+    getAdapter: async () => adapter
+  })
+})

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -251,7 +251,7 @@ describe.each([
   });
   const { adapter, opts } = getTestSchemaAdapter(db, {
     generate: {
-      roundDefaultTime: roundDefaultTime as 's' | 'ms' | false | undefined,
+      roundAtTimes: roundDefaultTime as 's' | 'ms' | false | undefined,
     }
   });
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, Test, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { surrealAdapter, SurrealBetterAuthConfig } from "../src";
 import { getDatabase } from "../db/surreal";
 import { BetterAuthOptions } from "better-auth/types";
@@ -238,8 +238,8 @@ describe("generate - enable records, disable on delete references", async () => 
 
 describe.each([
   's', 'ms', false
-])("generate - roundDefaultTime %p", async (roundDefaultTime) => {
-  const database = `better_auth_test_roundDefaultTime_${roundDefaultTime.toString()}`
+])("generate - floorDefaultTime %p", async (floorDefaultTime) => {
+  const database = `better_auth_test_floorDefaultTime_${floorDefaultTime.toString()}`
   const db = await getDatabase({
     url: "http://127.0.0.1:8000/rpc",
     namespace: "better_auth",
@@ -251,7 +251,7 @@ describe.each([
   });
   const { adapter, opts } = getTestSchemaAdapter(db, {
     generate: {
-      roundAtTimes: roundDefaultTime as 's' | 'ms' | false | undefined,
+      floorAtTimes: floorDefaultTime as 's' | 'ms' | false | undefined,
     }
   });
 
@@ -272,20 +272,20 @@ describe.each([
   test("schema generation", async () => {
     const schema = await adapter.createSchema!(opts)
 
-    if (roundDefaultTime) {
-      expect(schema.code).toContain(`time::round(time::now(), 1${roundDefaultTime})`)
+    if (floorDefaultTime) {
+      expect(schema.code).toContain(`time::floor(time::now(), 1${floorDefaultTime})`)
     } else {
       expect(schema.code).toContain("time::now()")
     }
 
     // Check createdAt, updatedAt, and expiresAt 
-    if (roundDefaultTime === false) {
+    if (floorDefaultTime === false) {
       expect(schema.code).toContain("DEFINE FIELD createdAt ON TABLE user TYPE datetime VALUE time::now() READONLY;");
       expect(schema.code).toContain("DEFINE FIELD updatedAt ON TABLE user TYPE datetime VALUE time::now();");
       expect(schema.code).toContain("DEFINE FIELD expiresAt ON TABLE sessions TYPE datetime;"); // not applied
     } else {
-      expect(schema.code).toContain(`DEFINE FIELD createdAt ON TABLE user TYPE datetime VALUE time::round(time::now(), 1${roundDefaultTime ?? 's'}) READONLY;`);
-      expect(schema.code).toContain(`DEFINE FIELD updatedAt ON TABLE user TYPE datetime VALUE time::round(time::now(), 1${roundDefaultTime ?? 's'});`);
+      expect(schema.code).toContain(`DEFINE FIELD createdAt ON TABLE user TYPE datetime VALUE time::floor(time::now(), 1${floorDefaultTime ?? 's'}) READONLY;`);
+      expect(schema.code).toContain(`DEFINE FIELD updatedAt ON TABLE user TYPE datetime VALUE time::floor(time::now(), 1${floorDefaultTime ?? 's'});`);
       expect(schema.code).toContain(`DEFINE FIELD expiresAt ON TABLE sessions TYPE datetime;`); // not applied
     }
 

--- a/tests/surreal-adapter.test.ts
+++ b/tests/surreal-adapter.test.ts
@@ -13,7 +13,7 @@ describe("adapter test", async () => {
       DEFINE NAMESPACE IF NOT EXISTS better_auth;
       DEFINE DATABASE IF NOT EXISTS better_auth;
       DELETE user;
-      DELETE session
+      DELETE sessions;
       `,
     );
   }
@@ -43,7 +43,6 @@ describe("adapter test", async () => {
         ...customOptions,
       });
     },
-    skipGenerateIdTest: true,
   });
 });
 
@@ -56,7 +55,7 @@ describe("simple-flow", async () => {
     },
   );
   const testUser = {
-    email: "test-eamil@email.com",
+    email: "test@email.com",
     password: "password",
     name: "Test Name",
   };

--- a/tests/testInstance.ts
+++ b/tests/testInstance.ts
@@ -31,7 +31,7 @@ export async function getTestInstance<
 ) {
   const db = await getDatabase({
     url: "http://127.0.0.1:8000/rpc",
-    namespace: "better_auth_test",
+    namespace: "better_auth",
     database: "better_auth_test",
     auth: { username: "root", password: "root" },
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"compilerOptions": {
 		"target": "ES2021",
-		"module": "ES2022",
-		"moduleResolution": "node",
+		"module": "node20",
+		"moduleResolution": "node16",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,


### PR DESCRIPTION
- Optimizes `findOne`, `update`, and `delete` with id search over `where` clause method
- Adds the ability to generate schemaful schemas via the createSchema function, runnable by `npx @better-auth/cli generate`
    - Adds optional types to schema
    - Can store values as `RecordId` on the database instead of `string` for fields ending in `Id`.
    - Generation can add default types including readonly `createdAt` and `updatedAt`.
    - Record references and their deletion behavior can be toggled off via flag `disableOnDeleteReference`
