### PR TITLE
Enable noUncheckedIndexedAccess and noPropertyAccessFromIndexSignature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealdb-better-auth",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": {
     "name": "Necmettin Karakaya",
     "url": "https://github.com/necmttn",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,
+		"noUncheckedIndexedAccess": true,
 		"skipLibCheck": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,
 		"noUncheckedIndexedAccess": true,
+		"noPropertyAccessFromIndexSignature": true,
 		"skipLibCheck": true
 	}
 }


### PR DESCRIPTION
Providing index.ts instead a declaration file causes consumers to type check the library code. If library is used in a project with stricter type-checks, it causes build errors.

This PR adds noUncheckedIndexedAccess and noPropertyAccessFromIndexSignature to enforce a stricter tsconfig in the library code.